### PR TITLE
Correct neighbor-view property usage

### DIFF
--- a/web/html/js/start.js
+++ b/web/html/js/start.js
@@ -13,7 +13,7 @@ function assignNeighborPopup(feature, layer){
 		"className": "neighbor-popup",
 		"autoPan": true,
 	});
-	popup.setContent(feature.properties);
+	popup.setContent(feature.properties.name);
  	layer.bindPopup(popup);
 	
 	layer.addEventListener('mouseover', function (e) {


### PR DESCRIPTION
Reference property "name" for popups instead of "properties"